### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/pr-nctl-scan.yml
+++ b/.github/workflows/pr-nctl-scan.yml
@@ -20,7 +20,7 @@ jobs:
 # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout manifests
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
       # - name: Download policies
       #   uses: actions/checkout@v2

--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -17,10 +17,10 @@ jobs:
 # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout template
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
       - name: Install Kyverno CLI
-        uses: kyverno/action-install-cli@v0.2.0
+        uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289  # v0.2.0
 
       - name: Check Kyverno install
         run: kyverno version


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `actions/checkout@v2 -> @ee0669bd...`
- `actions/checkout@v2 -> @ee0669bd...`
- `kyverno/action-install-cli@v0.2.0 -> @fcee92fc...`


### Why

Following the [TeamPCP/Checkmarx supply chain attack](https://thehackernews.com/2026/03/teampcp-hacks-checkmarx-github-actions.html), Nirmata is hardening all public repos against GitHub Actions tag hijacking. This repo was flagged as **CRITICAL** (unpinned actions + write permissions).

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
